### PR TITLE
Upgrading default runtime to Node 8/NPM 5

### DIFF
--- a/lib/AzureClient/templates/gitTemplate.json
+++ b/lib/AzureClient/templates/gitTemplate.json
@@ -84,7 +84,11 @@
                     "appSettings": [
                         {
                             "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                            "value": "6.9.1"
+                            "value": "8.0.0"
+                        },
+                        {
+                            "name": "WEBSITE_NPM_DEFAULT_VERSION",
+                            "value": "5.0.0"
                         },
                         {
                             "name": "APPINSIGHTS_INSTRUMENTATIONKEY",

--- a/lib/AzureClient/templates/template.json
+++ b/lib/AzureClient/templates/template.json
@@ -88,7 +88,11 @@
                     "appSettings": [
                         {
                             "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                            "value": "6.9.1"
+                            "value": "8.0.0"
+                        },
+                        {
+                            "name": "WEBSITE_NPM_DEFAULT_VERSION",
+                            "value": "5.0.0"
                         },
                         {
                             "name": "APPINSIGHTS_INSTRUMENTATIONKEY",


### PR DESCRIPTION
Now that Node 8/NPM 5 have been deployed to Windows Web Apps, this PR simply updates the default runtime version to use those bits (since `azjs` is meant to be very opinionated).

> Note: I didn't touch the Linux deployment templates since Node 8 isn't available yet as a base image.